### PR TITLE
Allow for authorization in RPC Client

### DIFF
--- a/rpc/client.go
+++ b/rpc/client.go
@@ -30,7 +30,7 @@ func (c *Client) send(body interface{}) (result []byte, err error) {
 	}
 	req.Header.Set("Content-Type", "application/json")
 	if c.AuthHeader != "" {
-		req.Header.Set("Authorization", AuthHeader)
+		req.Header.Set("Authorization", c.AuthHeader)
 	}
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -12,6 +12,7 @@ import (
 // Client is used for connecting to http rpc endpoints.
 type Client struct {
 	URL string
+	AuthHeader string
 	Ctx context.Context
 }
 
@@ -28,6 +29,9 @@ func (c *Client) send(body interface{}) (result []byte, err error) {
 		return
 	}
 	req.Header.Set("Content-Type", "application/json")
+	if c.AuthHeader != "" {
+		req.Header.Set("Authorization", AuthHeader)
+	}
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return


### PR DESCRIPTION
Adds a 'AuthHeader' property to the RPC Client struct. This is added to RPC requests as the Authorization header, and means private Nano nodes can be used. It's an option in the Nault wallet I found useful. I've not tested it here, but it shouldn't be a breaking change, and the Client should handle 401/403 errors as it normally would.