### PR TITLE
Makes it possible to add an account to a wallet based on its index.

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -19,12 +19,17 @@ var addCmd = &cobra.Command{
 			wi := wallets[walletIndex]
 			wi.init()
 			var a *wallet.Account
-			for {
-				var err error
-				a, err = wi.w.NewAccount(nil)
+			var err error
+			if (walletAccountIndex > 0) {
+				a, err = wi.w.NewAccount(&walletAccountIndex)
 				fatalIf(err)
-				if _, ok := wi.Accounts[a.Address()]; !ok {
-					break
+			} else {
+				for {
+					a, err = wi.w.NewAccount(nil)
+					fatalIf(err)
+					if _, ok := wi.Accounts[a.Address()]; !ok {
+						break
+					}
 				}
 			}
 			wi.Accounts[a.Address()] = a.Index()

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -21,7 +21,7 @@ var addCmd = &cobra.Command{
 			var a *wallet.Account
 			var err error
 			if (walletAccountIndex >= 0) {
-				var index = uint32(walletAccountIndex)
+				index := uint32(walletAccountIndex)
 				a, err = wi.w.NewAccount(&index)
 				fatalIf(err)
 			} else {

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -20,8 +20,9 @@ var addCmd = &cobra.Command{
 			wi.init()
 			var a *wallet.Account
 			var err error
-			if (walletAccountIndex > 0) {
-				a, err = wi.w.NewAccount(&walletAccountIndex)
+			if (walletAccountIndex >= 0) {
+				var index = uint32(walletAccountIndex)
+				a, err = wi.w.NewAccount(&index)
 				fatalIf(err)
 			} else {
 				for {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -45,7 +45,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&walletAccount, "account", "a", "", "Account to operate on")
 	rootCmd.PersistentFlags().StringVarP(&rpcURL, "rpc", "r", "https://mynano.ninja/api/node", "RPC endpoint URL")
 	rootCmd.PersistentFlags().StringVarP(&rpcWorkURL, "rpc-work", "s", "http://[::1]:7076", "RPC endpoint URL for work generation")
-	rootCmd.PersistentFlags().Uint32VarP(&walletAccountIndex, "account_index", "i", 0, "Index of the account within the wallet to use. Not all operations support it yet")	
+	rootCmd.PersistentFlags().IntVarP(&walletAccountIndex, "account_index", "i", -1, "Index of the account within the wallet to use. Not all operations support it yet")	
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -45,6 +45,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&walletAccount, "account", "a", "", "Account to operate on")
 	rootCmd.PersistentFlags().StringVarP(&rpcURL, "rpc", "r", "https://mynano.ninja/api/node", "RPC endpoint URL")
 	rootCmd.PersistentFlags().StringVarP(&rpcWorkURL, "rpc-work", "s", "http://[::1]:7076", "RPC endpoint URL for work generation")
+	rootCmd.PersistentFlags().Uint32VarP(&walletAccountIndex, "account_index", "i", 0, "Index of the account within the wallet to use. Not all operations support it yet")	
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -45,7 +45,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&walletAccount, "account", "a", "", "Account to operate on")
 	rootCmd.PersistentFlags().StringVarP(&rpcURL, "rpc", "r", "https://mynano.ninja/api/node", "RPC endpoint URL")
 	rootCmd.PersistentFlags().StringVarP(&rpcWorkURL, "rpc-work", "s", "http://[::1]:7076", "RPC endpoint URL for work generation")
-	rootCmd.PersistentFlags().IntVarP(&walletAccountIndex, "account_index", "i", -1, "Index of the account within the wallet to use. Not all operations support it yet")	
+	rootCmd.PersistentFlags().IntVarP(&walletAccountIndex, "account-index", "i", -1, "Index of the account within the wallet to use. Not all operations support it yet")	
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/cmd/wallet.go
+++ b/cmd/wallet.go
@@ -20,7 +20,7 @@ type walletInfo struct {
 var wallets []*walletInfo
 var walletIndex int
 var walletAccount string
-var walletAccountIndex uint32
+var walletAccountIndex int
 
 func initWallets() {
 	v := viper.GetStringMap("wallets")

--- a/cmd/wallet.go
+++ b/cmd/wallet.go
@@ -20,6 +20,7 @@ type walletInfo struct {
 var wallets []*walletInfo
 var walletIndex int
 var walletAccount string
+var walletAccountIndex uint32
 
 func initWallets() {
 	v := viper.GetStringMap("wallets")


### PR DESCRIPTION
Let me know what you think!

The idea is to use it to add accounts from previously known indexes. It also makes it easier to restore a wallet as well in case you end up creating too many accounts. I will be using this to map from accounts to another index in my integration with Nano, and it makes it easy to have a 1:1 mapping.

Usage: `gonano add -w0 -i987`